### PR TITLE
Fix cosine similarity location

### DIFF
--- a/src/detection_service/face_match.py
+++ b/src/detection_service/face_match.py
@@ -1,6 +1,11 @@
 import numpy as np
 from deepface import DeepFace
 
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Return cosine similarity between two vectors."""
+    return float(a.dot(b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
 def match_faces(
     img1_path: str,
     img2_path: str,
@@ -30,5 +35,5 @@ def match_faces(
         # no face found → treat as non-match
         return False, 0.0
 
-    sim = float(emb1.dot(emb2) / (np.linalg.norm(emb1) * np.linalg.norm(emb2)))
+    sim = cosine_similarity(emb1, emb2)
     return sim >= threshold, sim

--- a/src/detection_service/voice_match.py
+++ b/src/detection_service/voice_match.py
@@ -2,8 +2,7 @@ import numpy as np
 from resemblyzer import VoiceEncoder, preprocess_wav
 from pathlib import Path
 
-def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
-    return float(a.dot(b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+from .face_match import cosine_similarity
 
 def match_voices(wav1: str, wav2: str, threshold: float = 0.75):
     """

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,5 +1,5 @@
 import os
-from src.detection_service.face_match import cosine_similarity, match_faces
+from src.detection_service.face_match import match_faces, cosine_similarity
 from src.detection_service.voice_match import match_voices
 
 def test_cosine_similarity_perfect():


### PR DESCRIPTION
## Summary
- centralize `cosine_similarity` into `face_match`
- reference that helper from `voice_match`
- keep detection tests importing from `face_match`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687da64720c083339447a085c0983189