### PR TITLE
Add reverse image search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Uses [SerpApi](https://serpapi.com/) for basic web and YouTube search and includ
 - `GET /search/youtube/` – YouTube search
 - `GET /search/social/` – **stub** social media search
 - `GET /search/darkweb/` – **stub** dark web search
+- `POST /search/image/` – reverse image search (SerpApi)
 
 Set the environment variable `SERPAPI_KEY` for search endpoints.
 

--- a/src/search_service/image_search.py
+++ b/src/search_service/image_search.py
@@ -1,0 +1,33 @@
+import os
+import base64
+import serpapi
+from serpapi.exceptions import HTTPError
+
+API_KEY = os.getenv("SERPAPI_KEY")
+
+
+def search_by_image(image_path: str, num: int = 5) -> list:
+    """Reverse image search via SerpApi.
+
+    Returns a list of (title, link) tuples. Empty list on failure or missing API
+    key.
+    """
+    if not API_KEY:
+        return []
+    with open(image_path, "rb") as f:
+        content = base64.b64encode(f.read()).decode("utf-8")
+
+    params = {
+        "engine": "google_reverse_image",
+        "api_key": API_KEY,
+        "image_content": content,
+        "num": num,
+    }
+    try:
+        results = serpapi.search(params)
+    except HTTPError:
+        return []
+
+    # API returns results under "image_results" or similar
+    hits = results.get("image_results", [])
+    return [(r.get("title"), r.get("link")) for r in hits][:num]

--- a/src/search_service/main.py
+++ b/src/search_service/main.py
@@ -1,6 +1,8 @@
-from fastapi import FastAPI, Query
+import os
+from fastapi import FastAPI, Query, UploadFile, File
 from .serpapi_client import search_web, search_youtube
 from .extended_search import search_social_media, search_dark_web
+from .image_search import search_by_image
 from pydantic import BaseModel
 from typing import List, Tuple
 
@@ -30,4 +32,15 @@ def social_search(account: str = Query(..., description="Social media handle"), 
 def darkweb_search(q: str = Query(..., description="Search query"), limit: int = 10):
     """Search Tor-hidden services for the query."""
     results = search_dark_web(q, num=limit)
+    return [SearchResult(title=t, link=l) for t, l in results]
+
+
+@app.post("/search/image/", response_model=List[SearchResult])
+async def image_search(file: UploadFile = File(...), limit: int = 5):
+    """Search the web for matches to the uploaded image."""
+    tmp_path = f"/tmp/{file.filename}"
+    with open(tmp_path, "wb") as fh:
+        fh.write(await file.read())
+    results = search_by_image(tmp_path, num=limit)
+    os.remove(tmp_path)
     return [SearchResult(title=t, link=l) for t, l in results]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,5 @@
 from src.search_service.serpapi_client import search_web, search_youtube
+from src.search_service.image_search import search_by_image
 
 def test_web_search_returns_list():
     res = search_web("OpenAI", num=2)
@@ -15,3 +16,10 @@ def test_youtube_search_returns_list():
     for title, link in res:
         assert isinstance(title, str)
         assert "youtube.com" in link or link.startswith("http")
+
+
+def test_image_search_returns_list(tmp_path):
+    img = tmp_path / "sample.jpg"
+    img.write_bytes(b"fake")
+    res = search_by_image(str(img), num=1)
+    assert isinstance(res, list)


### PR DESCRIPTION
## Summary
- add reverse image search helper using SerpApi
- expose `/search/image/` endpoint
- document new endpoint
- test new `search_by_image` function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, serpapi)*

------
https://chatgpt.com/codex/tasks/task_e_6880580cbe5483339d557b9ea4d6a09a