### PR TITLE
Fix imports for uvicorn startup and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ pytest
 ```
 
 Some tests are placeholders and require sample media files.
+
+## Running the Server
+
+Start the combined FastAPI application with Uvicorn:
+
+```bash
+uvicorn src.app:app --reload
+```
+
+Ensure you install the required dependencies and set `SERPAPI_KEY` if you plan
+to use the search endpoints.

--- a/src/app.py
+++ b/src/app.py
@@ -3,11 +3,11 @@ from fastapi import FastAPI, Request, UploadFile, File, Form
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from detection_service.main import app as detection_app
-from identity_service.main import app as identity_app
-from search_service.main import app as search_app
-from detection_service.face_match import match_faces
-from detection_service.voice_match import match_voices
+from src.detection_service.main import app as detection_app
+from src.identity_service.main import app as identity_app
+from src.search_service.main import app as search_app
+from src.detection_service.face_match import match_faces
+from src.detection_service.voice_match import match_voices
 
 app = FastAPI(title="AI Deepfake Takedown")
 

--- a/src/detection_service/main.py
+++ b/src/detection_service/main.py
@@ -1,8 +1,8 @@
 import os
 from fastapi import FastAPI, UploadFile, File, Form
-from detection_service.face_match import match_faces
-from detection_service.voice_match import match_voices
-from detection_service.frame_extractor import download_video, extract_frames
+from .face_match import match_faces
+from .voice_match import match_voices
+from .frame_extractor import download_video, extract_frames
 
 app = FastAPI(title="Detection Service")
 


### PR DESCRIPTION
## Summary
- fix module imports to include `src.` prefix
- use relative imports inside detection_service
- document server startup in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, serpapi)*

------
https://chatgpt.com/codex/tasks/task_e_68805d5e999083338f40aa8bab875f8a