### PR TITLE
Adjust service route prefixes

### DIFF
--- a/src/detection_service/main.py
+++ b/src/detection_service/main.py
@@ -6,7 +6,7 @@ from .frame_extractor import download_video, extract_frames
 
 app = FastAPI(title="Detection Service")
 
-@app.post("/detect/face/")
+@app.post("/face/")
 async def detect_face(
     client: UploadFile = File(...),
     suspect: UploadFile = File(...),
@@ -26,7 +26,7 @@ async def detect_face(
     os.remove(tmp2)
     return {"matched": matched, "similarity": score}
 
-@app.post("/detect/voice/")
+@app.post("/voice/")
 async def detect_voice(
     client: UploadFile = File(...),
     suspect: UploadFile = File(...),
@@ -45,7 +45,7 @@ async def detect_voice(
     os.remove(tmp2)
     return {"matched": matched, "similarity": score}
 
-@app.post("/detect/video/")
+@app.post("/video/")
 async def detect_video(
     client: UploadFile = File(...),
     video_url: str = Form(...),
@@ -71,3 +71,4 @@ async def detect_video(
     for fp in frames:
         os.remove(fp)
     return {"matches": matches}
+

--- a/src/identity_service/main.py
+++ b/src/identity_service/main.py
@@ -4,7 +4,7 @@ from .fingerprint import extract_face_embedding, extract_voice_embedding
 
 app = FastAPI(title="Identity Fingerprint Service")
 
-@app.post("/fingerprint/face/")
+@app.post("/face/")
 async def face_fingerprint(file: UploadFile = File(...)):
     # save upload
     path = f"/tmp/{file.filename}"
@@ -13,7 +13,7 @@ async def face_fingerprint(file: UploadFile = File(...)):
     emb = extract_face_embedding(path)
     return {"embedding": emb.tolist()}
 
-@app.post("/fingerprint/voice/")
+@app.post("/voice/")
 async def voice_fingerprint(file: UploadFile = File(...)):
     path = f"/tmp/{file.filename}"
     with open(path, "wb") as f:

--- a/src/search_service/main.py
+++ b/src/search_service/main.py
@@ -12,30 +12,30 @@ class SearchResult(BaseModel):
     title: str
     link: str
 
-@app.get("/search/web/", response_model=List[SearchResult])
+@app.get("/web/", response_model=List[SearchResult])
 def web_search(q: str = Query(..., description="Search query"), limit: int = 10):
     results = search_web(q, num=limit)
     return [SearchResult(title=t, link=l) for t, l in results]
 
-@app.get("/search/youtube/", response_model=List[SearchResult])
+@app.get("/youtube/", response_model=List[SearchResult])
 def youtube_search(q: str = Query(..., description="Search query"), limit: int = 5):
     results = search_youtube(q, num=limit)
     return [SearchResult(title=t, link=l) for t, l in results]
 
-@app.get("/search/social/", response_model=List[SearchResult])
+@app.get("/social/", response_model=List[SearchResult])
 def social_search(account: str = Query(..., description="Social media handle"), limit: int = 10):
     """Search known social media sites for posts mentioning the account."""
     results = search_social_media(account, num=limit)
     return [SearchResult(title=t, link=l) for t, l in results]
 
-@app.get("/search/darkweb/", response_model=List[SearchResult])
+@app.get("/darkweb/", response_model=List[SearchResult])
 def darkweb_search(q: str = Query(..., description="Search query"), limit: int = 10):
     """Search Tor-hidden services for the query."""
     results = search_dark_web(q, num=limit)
     return [SearchResult(title=t, link=l) for t, l in results]
 
 
-@app.post("/search/image/", response_model=List[SearchResult])
+@app.post("/image/", response_model=List[SearchResult])
 async def image_search(file: UploadFile = File(...), limit: int = 5):
     """Search the web for matches to the uploaded image."""
     tmp_path = f"/tmp/{file.filename}"


### PR DESCRIPTION
## Summary
- streamline search API endpoints
- remove `/detect` prefix from detection routes
- remove `/fingerprint` prefix from identity routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688063f5daf88333aa623a937124fd9e